### PR TITLE
Allow the String "0" as a Value

### DIFF
--- a/src/Sasl.php
+++ b/src/Sasl.php
@@ -137,7 +137,7 @@ class Sasl
      */
     private function checkEmpty(array $array, $key)
     {
-        if (!empty($array[$key])) {
+        if (!empty($array[$key]) || $array[$key] === "0") {
             return $array[$key];
         }
 


### PR DESCRIPTION
In some places I use the username "0", and in one service that uses this library this meant I couldn't login because it would pass validation on their side, but then inside the library it was as though no username had been given.
I don't think that's the intention of this line.

Now, I tried to change as little as possible here to get my use-case to work, but you folks are the experts.
It could also be changed to something like:

```php
if ($array[$key] !== "")
```

If that's closer to what was actually meant. I think in the current form of this PR, anyone with the username of `"false"` would also be unable to login with this library.
